### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ project(SlicerDentalModelSeg)
 set(EXTENSION_HOMEPAGE "https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg/blob/main/readme.md")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Mathieu Leclercq (University of North Carolina), Connor Bowley (Kitware), Juan Carlos Prieto (University of North Carolina)")
-set(EXTENSION_DESCRIPTION "This extension aims to provide a GUI for a deep-learning automated teeth segmentation tool that we developed at the University of North Carolina in Chapel Hill.")
+set(EXTENSION_DESCRIPTION "This extension aims to provide a GUI for a deep-learning automated teeth segmentation tool developed at the University of North Carolina in Chapel Hill.")
 set(EXTENSION_ICONURL "https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg/raw/main/examples/logo_jaw_segmentation.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/DCBIA-OrthoLab/SlicerDentalModelSeg/blob/main/examples/segmentation_example.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/DCBIA-OrthoLab/SlicerDentalModelSeg/main/examples/segmentation_example.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.